### PR TITLE
bugfix for book-ids starting with zero

### DIFF
--- a/linux.sh
+++ b/linux.sh
@@ -97,7 +97,7 @@ cleanFile "$filename"
 
 while read -r line
 do
-    export bookId=$(echo -n "$line" | tr -d $'\r' | grep "[0-9]")
+    export bookId=$(echo -n "$line" | tr -d $'\r' | grep "[0-9]" | sed 's/^0*//')
     getFiles "$bookId" "$tingPath/\$ting"
 
 done < "$filename"


### PR DESCRIPTION
Book-ID from TBD.txt was `05100`

Download failed for
http://system.ting.eu/book-files/get-description/id/05100/area/en

Working link is this:
http://system.ting.eu/book-files/get-description/id/5100/area/en