### PR TITLE
Update Download URLs to Tingel Tangel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # TingScript
+
 Bash script for filling the TING pen with audio books under Linux, which have to be downloaded
 
 ## Requirements
+
 - TING pen with USB cable
 - bash as shell (maybe other can run well, but can't be guaranteed)
-
 
 ## Installation
 
@@ -19,6 +20,7 @@ Bash script for filling the TING pen with audio books under Linux, which have to
    ```
 
 ## Usage
+
 1. The script downloads "missing" books, i.e. books that the TING pen has "seen" but which are currently not stored on the pen. Therefore, turn on the pen and
 use it to touch the activation icons of all the books that you want to download.
 
@@ -41,9 +43,16 @@ use it to touch the activation icons of all the books that you want to download.
    The path that you pass should be the folder that contains the ``$ting``
    folder.
 
+## Attention
+
+The TING pen is not supported anymore.
+Thus, a project named <https://www.ting-el-tangel.de[Tingel> Tangel] has formed to conserve the old books and provide them for download.
+The download script has thus been updated accordingly.
+
 ## Contributors
-- Ralf Meyer https://github.com/ralfdonald
-- Bernd Wurst https://github.com/bwurst
-- Stefan Dangl https://github.com/stangls
-- frog23 https://github.com/frog23
-- Florian Brucker https://github.com/torfsen
+
+- Ralf Meyer <https://github.com/ralfdonald>
+- Bernd Wurst <https://github.com/bwurst>
+- Stefan Dangl <https://github.com/stangls>
+- frog23 <https://github.com/frog23>
+- Florian Brucker <https://github.com/torfsen>

--- a/linux.sh
+++ b/linux.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 DOWNLOAD_PREFIX="http://13.80.138.170/book-files"
-DOWNLOAD_PREFIX_GET_ID="$DOWNLOAD_PREFIX/get/id/"
-DOWNLOAD_PREFIX_GET_DESCRIPTION_ID="$DOWNLOAD_PREFIX/get-description/id/"
+DOWNLOAD_PREFIX_GET_ID="$DOWNLOAD_PREFIX/get/id"
+DOWNLOAD_PREFIX_GET_DESCRIPTION_ID="$DOWNLOAD_PREFIX/get-description/id"
 DOWNLOAD_AREA_EN_TYPE="area/en/type"
 DOWNLOAD_POSTFIX="sn/5497559973888/"
 
@@ -70,7 +70,7 @@ checkFiles() {
     echo "Kein Scriptfile notwendig"
   else
     echo "Downloade Scriptfile $1$scrEnd"
-    wget "$DOWNLOAD_PREFIX_GET_ID/$s/$DOWNLOAD_AREA_EN_TYPE/script/$DOWNLOAD_POSTFIX" -O "$2/$1$oufEnd"
+    wget "$DOWNLOAD_PREFIX_GET_ID/$s/$DOWNLOAD_AREA_EN_TYPE/script/$DOWNLOAD_POSTFIX" -O "$2/$1$scrEnd"
   fi
 
   echo ""

--- a/linux.sh
+++ b/linux.sh
@@ -80,7 +80,7 @@ getInfo() {
   # shellcheck disable=SC2001
   s="$(echo "$1" | sed 's/^0*//')"
   echo "short: $s"
-  wget $DOWNLOAD_PREFIX_GET_DESCRIPTION_ID/"$s"/$DOWNLOAD_AREA_EN/$DOWNLOAD_POSTFIX -O "$2"/"$1""$3"
+  wget $DOWNLOAD_PREFIX_GET_DESCRIPTION_ID/"$s"/$DOWNLOAD_AREA_EN_TYPE/$DOWNLOAD_POSTFIX -O "$2"/"$1""$3"
 }
 
 getFiles() {

--- a/linux.sh
+++ b/linux.sh
@@ -1,18 +1,23 @@
 #!/bin/bash
 
+DOWNLOAD_PREFIX="http://13.80.138.170/book-files"
+DOWNLOAD_PREFIX_GET_ID="$DOWNLOAD_PREFIX/get/id/"
+DOWNLOAD_PREFIX_GET_DESCRIPTION_ID="$DOWNLOAD_PREFIX/get-description/id/"
+DOWNLOAD_AREA_EN_TYPE="area/en/type"
+DOWNLOAD_POSTFIX="sn/5497559973888/"
+
 TING="${1}"
-if [ -z "${1}" ] ; then
-	TING="$(grep '/TING\s' /proc/mounts |cut -d ' ' -f 2)"
-	if ! [ -d "${TING}/\$ting" ] ; then
-		TING=
-	fi
+if [ -z "${1}" ]; then
+  TING="$(grep '/TING\s' /proc/mounts | cut -d ' ' -f 2)"
+  if ! [ -d "${TING}/\$ting" ]; then
+    TING=
+  fi
 fi
 
-
 if [ -z "${TING}" ]; then
-	echo "TING konnte nicht automatisch erkannt werden. Bitte gib den Mount-Point des TING-Stifts als Parameter mit."
-        echo "Usage: $0 [Ort des \$ting-Ordners]"
-        exit 1
+  echo "TING konnte nicht automatisch erkannt werden. Bitte gib den Mount-Point des TING-Stifts als Parameter mit."
+  echo "Usage: $0 [Ort des \$ting-Ordners]"
+  exit 1
 fi
 
 tingPath="$TING"
@@ -23,87 +28,88 @@ oufEnd="_en.ouf"
 scrEnd="_en.script"
 
 # entfernt ^M aus Datei und schreibt die Zeilen neu
-cleanFile () {
-    echo "Säubere File $1"
-    while read -r line
-    do
-        $(echo -n "$line" | tr -d $'\r' | grep "[0-9]" >> TBD_TEMP.TXT)
-    done < "$filename"
-    rm $1    
-    sort -u TBD_TEMP.TXT > $1
-    rm TBD_TEMP.TXT
-    echo ""
+cleanFile() {
+  echo "Säubere File $1"
+  while read -r line; do
+    echo -n "$line" | tr -d $'\r' | grep "[0-9]" >>"TBD_TEMP.TXT"
+  done <"$filename"
+  rm "$1"
+  sort -u TBD_TEMP.TXT >"$1"
+  rm TBD_TEMP.TXT
+  echo ""
 }
 
 # leert die ganze Datei
-emptyFile () {
-    echo "Leere File $1"
-    echo ""
-    truncate --size=0 $1
+emptyFile() {
+  echo "Leere File $1"
+  echo ""
+  truncate --size=0 "$1"
 }
 
-checkFiles () {
-    echo "Prüfe Datei $3";
-    thumbMD5=$(cat $3 | grep "ThumbMD5:" | grep -ow "[0-9a-z]*");
-    s=$(echo "$1" | sed 's/^0*//')
-    if [ -z $thumbMD5 ]; then
-        echo "Kein Vorschaubild notwendig"
-    else
-        echo "Downloade Vorschaubild $1$pngEnd"
-        wget http://system.ting.eu/book-files/get/id/$s/area/en/type/thumb -O $2/$1$pngEnd
-    fi
+checkFiles() {
+  echo "Prüfe Datei $3"
+  thumbMD5=$(grep "ThumbMD5:" "$3" | grep -ow "[0-9a-z]*")
+  # shellcheck disable=SC2001
+  s="$(echo "$1" | sed 's/^0*//')"
+  if [ -z "$thumbMD5" ]; then
+    echo "Kein Vorschaubild notwendig"
+  else
+    echo "Downloade Vorschaubild $1$pngEnd"
+    wget "$DOWNLOAD_PREFIX_GET_ID/$s/$DOWNLOAD_AREA_EN_TYPE/thumb/$DOWNLOAD_POSTFIX" -O "$2/$1$pngEnd"
+  fi
 
-    fileMD5=$(cat $3 | grep "FileMD5:" | grep -ow "[0-9a-z]*")
-    if [ -z $fileMD5 ]; then
-        echo "Kein Buchfile notwendig"
-    else
-        echo "Downloade Buchfile $1$oufEnd"
-        wget http://system.ting.eu/book-files/get/id/$s/area/en/type/archive -O $2/$1$oufEnd
-    fi
-    scriptMD5=$(cat $3 | grep "ScriptMD5:" | grep -ow "[0-9a-z]*")
-    if [ -z $scriptMD5 ]; then
-        echo "Kein Scriptfile notwendig"
-    else
-        echo "Downloade Scriptfile $1$scrEnd"
-        wget http://system.ting.eu/book-files/get/id/$s/area/en/type/script -O $2/$1$scrEnd
-    fi
+  fileMD5=$(grep "FileMD5:" "$3" | grep -ow "[0-9a-z]*")
+  if [ -z "$fileMD5" ]; then
+    echo "Kein Buchfile notwendig"
+  else
+    echo "Downloade Buchfile $1$oufEnd"
+    wget "$DOWNLOAD_PREFIX_GET_ID/$s/$DOWNLOAD_AREA_EN_TYPE/archive/$DOWNLOAD_POSTFIX" -O "$2/$1$oufEnd"
+  fi
+  scriptMD5=$(grep "ScriptMD5:" "$3" | grep -ow "[0-9a-z]*")
+  if [ -z "$scriptMD5" ]; then
+    echo "Kein Scriptfile notwendig"
+  else
+    echo "Downloade Scriptfile $1$scrEnd"
+    wget "$DOWNLOAD_PREFIX_GET_ID/$s/$DOWNLOAD_AREA_EN_TYPE/script/$DOWNLOAD_POSTFIX" -O "$2/$1$oufEnd"
+  fi
 
-    echo ""
+  echo ""
 }
 
-getInfo () {
-    s=$(echo "$1" | sed 's/^0*//')
-    echo "short: $s"
-    wget http://system.ting.eu/book-files/get-description/id/"$s"/area/en -O "$2"/"$1""$3"
+getInfo() {
+  # shellcheck disable=SC2001
+  s="$(echo "$1" | sed 's/^0*//')"
+  echo "short: $s"
+  wget $DOWNLOAD_PREFIX_GET_DESCRIPTION_ID/"$s"/$DOWNLOAD_AREA_EN/$DOWNLOAD_POSTFIX -O "$2"/"$1""$3"
 }
 
-getFiles () {
-    bookId=$1
-    echo "Lade BuchId $bookId"
-    getInfo $bookId "$2" $txtEnd
-    checkFiles $bookId $2 "$2/$1$3$txtEnd"
-    echo ""
+getFiles() {
+  bookId=$1
+  echo "Lade BuchId $bookId"
+  getInfo "$bookId" "$2" "$txtEnd"
+  checkFiles "$bookId" "$2" "$2/$1$3$txtEnd"
+  echo ""
 }
 
 echo "Ort des \$ting-Ordner: $tingPath"
 
 filename="$tingPath/\$ting/TBD.TXT"
-if ! [ -f "$filename" ] ; then
-	filename="$tingPath/\$ting/tbd.txt"
+if ! [ -f "$filename" ]; then
+  filename="$tingPath/\$ting/tbd.txt"
 fi
 
-if [ "$(wc -l "$filename"|cut -d ' ' -f 1)" == 0 ] ; then
-	echo 'Kein fehlendes Buch gefunden.'
-	exit 0
+if [ "$(wc -l "$filename" | cut -d ' ' -f 1)" == 0 ]; then
+  echo 'Kein fehlendes Buch gefunden.'
+  exit 0
 fi
-	
+
 cleanFile "$filename"
 
-while read -r line
-do
-    export bookId=$(echo -n "$line" | tr -d $'\r' | grep "[0-9]")
-    getFiles "$bookId" "$tingPath/\$ting"
+while read -r line; do
+  bookId="$(echo -n "$line" | tr -d $'\r' | grep "[0-9]")"
+  export bookId
+  getFiles "$bookId" "$tingPath/\$ting"
 
-done < "$filename"
+done <"$filename"
 
 emptyFile "$filename"


### PR DESCRIPTION
The TING pen is not officially supported anymore and the original producer has sold the branch. Thus, the download URLs in the script are not working anymore. This patch updates the script to use the download URLs of Tingel Tangel, a project which conserves the digital media of the TING pen so you can still use it.